### PR TITLE
Drop explicit "rails" dependency in favour of slimmer "railties"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### [0.0.10] - 2021-03-26
+
+* Only require `railties` and `actionpack` to successfully run
+
 ### [0.0.9] - 2021-01-28
 * Remove Rails 5 support
 * Update Readme
@@ -16,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add a changelog
 * Setup automated gem publishing
 
-[Unreleased]: https://github.com/zaikio/zaikio-webhooks/compare/v0.0.9...HEAD
+[Unreleased]: https://github.com/zaikio/zaikio-webhooks/compare/v0.0.10...HEAD
+[0.0.10]: https://github.com/zaikio/zaikio-webhooks/compare/v0.0.9...v0.0.10
 [0.0.9]: https://github.com/zaikio/zaikio-webhooks/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/zaikio/zaikio-webhooks/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/zaikio/zaikio-webhooks/compare/55b26b3ea3982f13814d5b96e8650001f43fdc07...v0.0.7

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,11 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
+gem "actionview"
+gem "activejob"
+gem "activemodel"
+gem "sprockets-rails"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,30 +2,12 @@ PATH
   remote: .
   specs:
     zaikio-webhooks (0.0.9)
-      rails (~> 6.0, >= 6.0.2.2)
+      actionpack (~> 6.0, >= 6.0.2.2)
+      railties (~> 6.0, >= 6.0.2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.1.3)
-      actionpack (= 6.1.3)
-      activesupport (= 6.1.3)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (6.1.3)
-      actionpack (= 6.1.3)
-      activejob (= 6.1.3)
-      activerecord (= 6.1.3)
-      activestorage (= 6.1.3)
-      activesupport (= 6.1.3)
-      mail (>= 2.7.1)
-    actionmailer (6.1.3)
-      actionpack (= 6.1.3)
-      actionview (= 6.1.3)
-      activejob (= 6.1.3)
-      activesupport (= 6.1.3)
-      mail (~> 2.5, >= 2.5.4)
-      rails-dom-testing (~> 2.0)
     actionpack (6.1.3)
       actionview (= 6.1.3)
       activesupport (= 6.1.3)
@@ -33,12 +15,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (6.1.3)
-      actionpack (= 6.1.3)
-      activerecord (= 6.1.3)
-      activestorage (= 6.1.3)
-      activesupport (= 6.1.3)
-      nokogiri (>= 1.8.5)
     actionview (6.1.3)
       activesupport (= 6.1.3)
       builder (~> 3.1)
@@ -50,16 +26,6 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.1.3)
       activesupport (= 6.1.3)
-    activerecord (6.1.3)
-      activemodel (= 6.1.3)
-      activesupport (= 6.1.3)
-    activestorage (6.1.3)
-      actionpack (= 6.1.3)
-      activejob (= 6.1.3)
-      activerecord (= 6.1.3)
-      activesupport (= 6.1.3)
-      marcel (~> 0.3.1)
-      mimemagic (~> 0.3.2)
     activesupport (6.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -79,17 +45,10 @@ GEM
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
-      mini_mime (>= 0.1.1)
-    marcel (0.3.3)
-      mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.6)
-    mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     mocha (1.12.0)
-    nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -100,21 +59,6 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (6.1.3)
-      actioncable (= 6.1.3)
-      actionmailbox (= 6.1.3)
-      actionmailer (= 6.1.3)
-      actionpack (= 6.1.3)
-      actiontext (= 6.1.3)
-      actionview (= 6.1.3)
-      activejob (= 6.1.3)
-      activemodel (= 6.1.3)
-      activerecord (= 6.1.3)
-      activestorage (= 6.1.3)
-      activesupport (= 6.1.3)
-      bundler (>= 1.15.0)
-      railties (= 6.1.3)
-      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -160,20 +104,21 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
-    websocket-driver (0.7.3)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionview
+  activejob
+  activemodel
   byebug
   mocha
   rubocop
   rubocop-performance
   rubocop-rails
+  sprockets-rails
   zaikio-webhooks!
 
 BUNDLED WITH

--- a/lib/zaikio/webhooks/version.rb
+++ b/lib/zaikio/webhooks/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module Webhooks
-    VERSION = "0.0.9".freeze
+    VERSION = "0.0.10".freeze
   end
 end

--- a/zaikio-webhooks.gemspec
+++ b/zaikio-webhooks.gemspec
@@ -22,5 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.required_ruby_version = ">= 2.6.5"
-  spec.add_dependency "rails", "~> 6.0", ">= 6.0.2.2"
+
+  spec.add_dependency "actionpack", "~> 6.0", ">= 6.0.2.2"
+  spec.add_dependency "railties", "~> 6.0", ">= 6.0.2.2"
 end


### PR DESCRIPTION
The [mimemagic incident](https://twitter.com/nateberkopec/status/1374722404228853762) has shown that it's always good to require as few dependencies as possible. A Rails Engine only needs the `railties` gem, plus whatever else it does internally, so instead of pulling in the whole of Rails for our gem we can just pick and choose the parts we want.