### PR TITLE
Fix bug where `event.payload` is converted to a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix bug where `event.payload` is converted to a String
+
 ### [0.0.10] - 2021-03-26
 
 * Only require `railties` and `actionpack` to successfully run

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    zaikio-webhooks (0.0.9)
+    zaikio-webhooks (0.0.10)
       actionpack (~> 6.0, >= 6.0.2.2)
+      activejob (~> 6.0, >= 6.0.2.2)
       railties (~> 6.0, >= 6.0.2.2)
 
 GEM

--- a/app/controllers/zaikio/webhooks/webhooks_controller.rb
+++ b/app/controllers/zaikio/webhooks/webhooks_controller.rb
@@ -31,7 +31,7 @@ module Zaikio
 
       def event_params
         params.permit(:id, :client_name, :name, :subject, :timestamp,
-                      :version, :link, :received_at, payload: {})
+                      :version, :link, :received_at, payload: {}).to_h
       end
     end
   end

--- a/lib/zaikio/webhooks/event_serializer.rb
+++ b/lib/zaikio/webhooks/event_serializer.rb
@@ -10,7 +10,7 @@ module Zaikio
       end
 
       def deserialize(data)
-        Event.new(data)
+        Event.new(data.without("_aj_serialized"))
       end
     end
   end

--- a/test/zaikio/webhooks/event_serializer_test.rb
+++ b/test/zaikio/webhooks/event_serializer_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Zaikio::Webhooks::EventSerializerTest < ActiveSupport::TestCase
+  test "it stably serializes then deserializes an Event" do
+    event_data = {
+      "client_name" => "my_app",
+      "id" => "62abcc92-e17e-4db0-b78e-13369251474b",
+      "name" => "directory.machine_added",
+      "subject" => "Org/2b271d51-e447-4a16-810f-5abdc596700a",
+      "timestamp" => "2019-11-26T10:58:09.000Z",
+      "version" => "1.0",
+      "received_at" => "2019-11-26T10:58:09.000Z",
+      "payload" => {
+        "machine_id" => "9709f0f1-d00b-48fa-bb01-8c52bbd7296e",
+        "site_id" => "80ef6969-0b4d-4959-8833-875d601f0922"
+      },
+      "link" => "https://directory.sandbox.zaikio.com/api/v1/machines/9709f0f1-d00b-48fa-bb01-8c52bbd7296e"
+    }
+    params = ActionController::Parameters.new(event_data).permit(:id, :client_name, :name, :subject, :timestamp, :version, :link, :received_at, payload: {})
+    event = Zaikio::Webhooks::Event.new(params)
+
+    serialized = Zaikio::Webhooks::EventSerializer.serialize(event)
+    deserialized = Zaikio::Webhooks::EventSerializer.deserialize(serialized)
+
+    assert_equal event, deserialized
+  end
+end

--- a/zaikio-webhooks.gemspec
+++ b/zaikio-webhooks.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.5"
 
   spec.add_dependency "actionpack", "~> 6.0", ">= 6.0.2.2"
+  spec.add_dependency "activejob", "~> 6.0", ">= 6.0.2.2"
   spec.add_dependency "railties", "~> 6.0", ">= 6.0.2.2"
 end


### PR DESCRIPTION
This has been causing an exciting bug in Procurement. The parameters were getting cast incorrectly. I'm not sure how best to test this, short of a full integration test?