### PR TITLE
Stringify keys when constructing Zaikio::Webhook::Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Allow using symbol keys when constructing `Zaikio::Webhooks::Event` (all keys are cast
+  to strings for reading).
+
 ## [0.1.0] - 2022-01-04
 
 * Switch `Zaikio::Webhooks::Event#data` from an `OpenStruct` to a `Hash`. Note that `id`,

--- a/lib/zaikio/webhooks/event.rb
+++ b/lib/zaikio/webhooks/event.rb
@@ -10,6 +10,8 @@ module Zaikio
       def_delegators :data, :to_h
 
       def initialize(event_data)
+        event_data = event_data.to_h.stringify_keys
+
         event_data.each do |key, value|
           instance_variable_set("@#{key}", value)
         end

--- a/test/zaikio/webhooks/event_test.rb
+++ b/test/zaikio/webhooks/event_test.rb
@@ -29,4 +29,33 @@ class Zaikio::Webhooks::EventTest < ActiveSupport::TestCase
     assert_equal "Organization", event.subject_type
     assert_equal "2b271d51-e447-4a16-810f-5abdc596700a", event.subject_id
   end
+
+  test "events constructed with symbol keys are still parsed correctly" do
+    event_data = {
+      client_name: "my_app",
+      id: "62abcc92-e17e-4db0-b78e-13369251474b",
+      name: "directory.machine_added",
+      subject: "Org/2b271d51-e447-4a16-810f-5abdc596700a",
+      timestamp: "2019-11-26T10:58:09.000Z",
+      version: "1.0",
+      received_at: "2019-11-26T10:58:09.000Z",
+      payload: {
+        "machine_id" => "9709f0f1-d00b-48fa-bb01-8c52bbd7296e",
+        "site_id" => "80ef6969-0b4d-4959-8833-875d601f0922"
+      },
+      link: "https://directory.sandbox.zaikio.com/api/v1/machines/9709f0f1-d00b-48fa-bb01-8c52bbd7296e"
+    }
+    event = Zaikio::Webhooks::Event.new(event_data)
+
+    assert_equal event_data[:id], event.id
+    assert_equal event_data[:client_name], event.client_name
+    assert_equal event_data[:name], event.name
+    assert_equal event_data[:version], event.version
+    assert_equal event_data[:payload], event.payload
+    assert_equal event_data[:link], event.link
+    assert_equal DateTime.new(2019, 11, 26, 10, 58, 9), event.created_at
+    assert_equal DateTime.new(2019, 11, 26, 10, 58, 9), event.received_at
+    assert_equal "Organization", event.subject_type
+    assert_equal "2b271d51-e447-4a16-810f-5abdc596700a", event.subject_id
+  end
 end


### PR DESCRIPTION
This makes it a bit easier to test with when using outside of a regular controller context. Note that we need to also cast to hash, because it might be invoked with ActionController::Parameters.