### PR TITLE
Pass custom options to job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Allow using symbol keys when constructing `Zaikio::Webhooks::Event` (all keys are cast
   to strings for reading).
+* `options` are passed to keyword arguments to the job when it is scheduled
 
 ## [0.1.0] - 2022-01-04
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Rails.application.reloader.to_prepare do
                       perform_now: true
   # Only for a specific client
   Zaikio::Webhooks.on "directory.machine_added", AddMachineJob,
-                      client_name: :my_app
+                      client_name: :my_app, options: { custom_keyword_argument_for_job: "value" }
 end
 ```
 

--- a/app/controllers/zaikio/webhooks/webhooks_controller.rb
+++ b/app/controllers/zaikio/webhooks/webhooks_controller.rb
@@ -8,7 +8,7 @@ module Zaikio
         Zaikio::Webhooks.webhooks_for(params[:client_name], event_params[:name])
                         .each do |job_klass, options|
           job_klass.public_send(options[:perform_now] ? :perform_now : :perform_later,
-                                Zaikio::Webhooks::Event.new(event_params))
+                                Zaikio::Webhooks::Event.new(event_params), **options[:options])
         end
 
         head :ok

--- a/lib/zaikio/webhooks.rb
+++ b/lib/zaikio/webhooks.rb
@@ -35,7 +35,7 @@ module Zaikio
         (@webhooks.dig(client_name.to_s, event_name.to_s) || {})
       end
 
-      def on(event_name, job_klass, client_name: nil, perform_now: false)
+      def on(event_name, job_klass, client_name: nil, perform_now: false, options: {})
         @webhooks ||= {}
 
         after_configuration do
@@ -44,7 +44,8 @@ module Zaikio
             @webhooks[name] ||= {}
             @webhooks[name][event_name.to_s] ||= {}
             @webhooks[name][event_name.to_s][job_klass] = {
-              perform_now: perform_now
+              perform_now: perform_now,
+              options: options
             }
           end
         end

--- a/test/controllers/zaikio/webhooks/webhooks_controller_test.rb
+++ b/test/controllers/zaikio/webhooks/webhooks_controller_test.rb
@@ -9,7 +9,7 @@ class MyOtherJob < ApplicationJob
 end
 
 class MyThirdJob < ApplicationJob
-  def perform(event_data); end
+  def perform(event_data, custom_option:); end
 end
 
 module Zaikio
@@ -37,7 +37,8 @@ module Zaikio
         Zaikio::Webhooks.on "directory.revoked_access_token", MyOtherJob,
                             client_name: "other_app", perform_now: perform_now
         Zaikio::Webhooks.on "directory.revoked_access_token", MyThirdJob,
-                            perform_now: !perform_now
+                            perform_now: !perform_now,
+                            options: { custom_option: "a" }
       end
 
       test "does nothing with no signature / secret" do
@@ -78,7 +79,8 @@ module Zaikio
         MyOtherJob.expects(:perform_later).never
         MyThirdJob.expects(:perform_later).never
         MyThirdJob.expects(:perform_now).with(
-          Zaikio::Webhooks::Event.new(data.merge("client_name" => "my_app"))
+          Zaikio::Webhooks::Event.new(data.merge("client_name" => "my_app")),
+          custom_option: "a"
         )
         MyJob.expects(:perform_now).never
         post zaikio_webhooks.root_path("my_app"), params: data.to_json, headers: {

--- a/test/zaikio/webhooks_test.rb
+++ b/test/zaikio/webhooks_test.rb
@@ -32,22 +32,24 @@ class Zaikio::Webhooks::Test < ActiveSupport::TestCase
     end
 
     assert_equal({
-                   "my_app" => { "my_event" => { MyTestJob => { perform_now: false } } }
+                   "my_app" => { "my_event" => { MyTestJob => {
+                     perform_now: false, options: {}
+                   } } }
                  }, Zaikio::Webhooks.webhooks)
 
     Zaikio::Webhooks.on "my_other_event", MyTestJob
 
-    assert_equal({ MyTestJob => { perform_now: false } },
+    assert_equal({ MyTestJob => { perform_now: false, options: {} } },
                  Zaikio::Webhooks.webhooks["my_app"]["my_other_event"])
 
     Zaikio::Webhooks.on "my_other_event", MyTestJob
 
-    assert_equal({ MyTestJob => { perform_now: false } },
+    assert_equal({ MyTestJob => { perform_now: false, options: {} } },
                  Zaikio::Webhooks.webhooks["my_app"]["my_other_event"])
 
     Zaikio::Webhooks.on "my_other_event", MyTestJob, perform_now: true
 
-    assert_equal({ MyTestJob => { perform_now: true } },
+    assert_equal({ MyTestJob => { perform_now: true, options: {} } },
                  Zaikio::Webhooks.webhooks["my_app"]["my_other_event"])
   end
 
@@ -64,7 +66,7 @@ class Zaikio::Webhooks::Test < ActiveSupport::TestCase
     end
 
     assert_equal(
-      { "my_event" => { MyTestJob => { perform_now: false } } },
+      { "my_event" => { MyTestJob => { perform_now: false, options: {} } } },
       Zaikio::Webhooks.webhooks.fetch("idempotent_app")
     )
   end


### PR DESCRIPTION
This improvement is needed so we can provide reusable but configurable jobs in `zaikio-hub-models`